### PR TITLE
feat: set up initial project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+logs/
+*.log
+
+# Environment variables
+.env
+.env.local
+
+# Temporary files
+tmp/
+temp/
+
+# Database credentials (when added later)
+*credentials*
+*config*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# mock_project3
-A Database Application to Create and Represent Chess Matches
+# ChessDB Application
+
+A database-driven chess tournament management system built for CMPE 321 - Introduction to Database Systems.
+
+## Project Overview
+
+ChessDB is a comprehensive tournament management application that handles chess tournaments in compliance with FIDE standards. The system supports multiple user roles and enables real-world operations such as match scheduling, player selection, and rule-compliant rating submissions.
+
+## Project Structure
+
+```
+├── backend/          # Server-side application code
+├── frontend/         # Client-side interface code
+├── README.md         # Project documentation
+└── CMPE321_Spring25_Project3.pdf  # Project requirements
+```
+
+## User Roles
+
+- **Database Managers**: System administrators with user management capabilities
+- **Players**: Registered users with ELO ratings and match participation
+- **Coaches**: Team managers responsible for match scheduling and player selection
+- **Arbiters**: Match officials responsible for rating completed matches
+
+## Setup Instructions
+
+*Framework selection and setup instructions will be added in subsequent development phases.*
+
+## Development Status
+
+🚧 **In Development** - Initial project structure setup complete
+
+## Team
+
+- Developer: efemantarci
+- Course: CMPE 321, Spring 2025

--- a/backend/.gitkeep
+++ b/backend/.gitkeep
@@ -1,0 +1,1 @@
+# This file keeps the backend directory in git

--- a/frontend/.gitkeep
+++ b/frontend/.gitkeep
@@ -1,0 +1,1 @@
+# This file keeps the frontend directory in git


### PR DESCRIPTION
  ## Summary
  Sets up the initial project structure for the ChessDB application.

  ## Changes
  - ✅ Created `backend/` directory for server-side code
  - ✅ Created `frontend/` directory for client-side code
  - ✅ Added comprehensive `.gitignore` for development files
  - ✅ Updated `README.md` with project overview and structure
  - ✅ Added `.gitkeep` files to preserve empty directories

  Closes #4

  🤖 Generated with [Claude Code](https://claude.ai/code)